### PR TITLE
Nuevo error en login

### DIFF
--- a/src/components/app/landing/landing-auth-modal/forgot-password-form.js
+++ b/src/components/app/landing/landing-auth-modal/forgot-password-form.js
@@ -23,9 +23,9 @@ class ForgotPasswordForm extends WebComponent {
                 });
                 this.emit('CLOSE_MODAL');
             })
-            .catch(() => {
+            .catch(e => {
                 input.classList.add('input-error');
-                errorMessageElement.textContent = this.translator.translate('LANDING.ERROR.PASS_RESET');
+                errorMessageElement.textContent = this.translator.translate(e.error);
                 errorMessageElement.classList.remove('hidden');
             });
     }

--- a/src/components/app/landing/landing-auth-modal/forgot-password-form.js
+++ b/src/components/app/landing/landing-auth-modal/forgot-password-form.js
@@ -23,9 +23,9 @@ class ForgotPasswordForm extends WebComponent {
                 });
                 this.emit('CLOSE_MODAL');
             })
-            .catch(e => {
+            .catch(() => {
                 input.classList.add('input-error');
-                errorMessageElement.textContent = this.translator.translate(e.error);
+                errorMessageElement.textContent = this.translator.translate('ERROR.USER.PASS_RESET');
                 errorMessageElement.classList.remove('hidden');
             });
     }

--- a/src/components/app/landing/landing-auth-modal/login-form.js
+++ b/src/components/app/landing/landing-auth-modal/login-form.js
@@ -36,9 +36,9 @@ class LoginForm extends WebComponent {
                 });
                 setTimeout(() => NavigatorService.goToHome(), 1000);
             }
-        }).catch(() => {
+        }).catch(e => {
             input.forEach(input => input.classList.add('input-error'));
-            errorMessageElement.textContent = this.translator.translate('LANDING.ERROR.INVALID_LOGIN');
+            errorMessageElement.textContent = this.translator.translate(e.error);
             errorMessageElement.classList.remove('hidden');
         });
     }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -80,10 +80,6 @@
       "CONFIRM_PASSWORD": "Confirm Password",
       "CONFIRM_PASSWORD_PHOLDER": "Confirm your password"
     },
-    "ERROR": {
-      "INVALID_LOGIN": "Invalid username or password",
-      "PASS_RESET": "No user or email matches the given input"
-    },
     "REGISTER": {
       "TERMS": "I agree to the <a href='/terms-conditions' class='terms-link' rel='noreferrer' target='_blank'>Terms and Conditions</a>",
       "OPTION_TEXT": "- OR REGISTER WITH -"
@@ -310,7 +306,10 @@
     },
     "OAUTH": {
       "NO_CODE": "Oops, why are you here? 🤔"
-    }
+    },
+    "INVALID_LOGIN": "Invalid username or password",
+    "USER_NOT_VERIFIED": "User not verified",
+    "PASS_RESET": "No user or email matches the given input"
   },
   "LANGUAGE": {
     "ES": "Spanish",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -309,9 +309,9 @@
     },
     "USER": {
       "INVALID_LOGIN": "Invalid username or password",
-      "NOT_VERIFIED": "User not verified"
-    },
-    "PASS_RESET": "No user or email matches the given input"
+      "NOT_VERIFIED": "User not verified",
+      "PASS_RESET": "No user or email matches the given input"
+    }
   },
   "LANGUAGE": {
     "ES": "Spanish",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -307,8 +307,10 @@
     "OAUTH": {
       "NO_CODE": "Oops, why are you here? 🤔"
     },
-    "INVALID_LOGIN": "Invalid username or password",
-    "USER_NOT_VERIFIED": "User not verified",
+    "USER": {
+      "INVALID_LOGIN": "Invalid username or password",
+      "NOT_VERIFIED": "User not verified"
+    },
     "PASS_RESET": "No user or email matches the given input"
   },
   "LANGUAGE": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -80,10 +80,6 @@
       "CONFIRM_PASSWORD": "Confirmar contraseña",
       "CONFIRM_PASSWORD_PHOLDER": "Confirma tu contraseña"
     },
-    "ERROR": {
-      "INVALID_LOGIN": "Usuario o contraseña inválidos",
-      "PASS_RESET": "No existe usuario o email que coincida con el dato proporcionado"
-    },
     "REGISTER": {
       "TERMS": "Acepto los <a href='/terms-conditions' class='terms-link' rel='noreferrer' target='_blank'>Términos y Condiciones</a>",
       "OPTION_TEXT": "- O REGÍSTRATE CON -"
@@ -310,7 +306,10 @@
     },
     "OAUTH": {
       "NO_CODE": "Uy, ¿porqué estás aquí? 🤔"
-    }
+    },
+    "INVALID_LOGIN": "Usuario o contraseña inválidos",
+    "USER_NOT_VERIFIED": "Usuario no verificado",
+    "PASS_RESET": "No existe usuario o email que coincida con el dato proporcionado"
   },
   "LANGUAGE": {
     "ES": "Español",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -309,9 +309,9 @@
     },
     "USER": {
       "INVALID_LOGIN": "Usuario o contraseña inválidos",
-      "NOT_VERIFIED": "Usuario no verificado"
-    },
-    "PASS_RESET": "No existe usuario o email que coincida con el dato proporcionado"
+      "NOT_VERIFIED": "Usuario no verificado",
+      "PASS_RESET": "No existe usuario o email que coincida con el dato proporcionado"
+    }
   },
   "LANGUAGE": {
     "ES": "Español",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -307,8 +307,10 @@
     "OAUTH": {
       "NO_CODE": "Uy, ¿porqué estás aquí? 🤔"
     },
-    "INVALID_LOGIN": "Usuario o contraseña inválidos",
-    "USER_NOT_VERIFIED": "Usuario no verificado",
+    "USER": {
+      "INVALID_LOGIN": "Usuario o contraseña inválidos",
+      "NOT_VERIFIED": "Usuario no verificado"
+    },
     "PASS_RESET": "No existe usuario o email que coincida con el dato proporcionado"
   },
   "LANGUAGE": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -307,8 +307,10 @@
     "OAUTH": {
       "NO_CODE": "Oups, pourquoi es-tu ici? 🤔"
     },
-    "INVALID_LOGIN": "Nom d'utilisateur ou mot de passe invalide",
-    "USER_NOT_VERIFIED": "Utilisateur non vérifié",
+    "USER": {
+      "INVALID_LOGIN": "Nom d'utilisateur ou mot de passe invalide",
+      "NOT_VERIFIED": "Utilisateur non vérifié"
+    },
     "PASS_RESET": "Aucun utilisateur ni email ne correspond aux données fournies"
   },
   "LANGUAGE": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -80,10 +80,6 @@
       "CONFIRM_PASSWORD": "Confirmer le mot de passe",
       "CONFIRM_PASSWORD_PHOLDER": "Confirmez votre mot de passe"
     },
-    "ERROR": {
-      "INVALID_LOGIN": "Nom d'utilisateur ou mot de passe invalide",
-      "PASS_RESET": "Aucun utilisateur ni email ne correspond aux données fournies"
-    },
     "REGISTER": {
       "TERMS": "J'accepte les <a href='/terms-conditions' class='terms-link' rel='noreferrer' target='_blank'>Conditions Générales</a>",
       "OPTION_TEXT": "- OU INSCRIVEZ-VOUS AVEC -"
@@ -310,7 +306,10 @@
     },
     "OAUTH": {
       "NO_CODE": "Oups, pourquoi es-tu ici? 🤔"
-    }
+    },
+    "INVALID_LOGIN": "Nom d'utilisateur ou mot de passe invalide",
+    "USER_NOT_VERIFIED": "Utilisateur non vérifié",
+    "PASS_RESET": "Aucun utilisateur ni email ne correspond aux données fournies"
   },
   "LANGUAGE": {
     "ES": "Espagnol",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -309,9 +309,9 @@
     },
     "USER": {
       "INVALID_LOGIN": "Nom d'utilisateur ou mot de passe invalide",
-      "NOT_VERIFIED": "Utilisateur non vérifié"
-    },
-    "PASS_RESET": "Aucun utilisateur ni email ne correspond aux données fournies"
+      "NOT_VERIFIED": "Utilisateur non vérifié",
+      "PASS_RESET": "Aucun utilisateur ni email ne correspond aux données fournies"
+    }
   },
   "LANGUAGE": {
     "ES": "Espagnol",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -309,9 +309,9 @@
     },
     "USER": {
       "INVALID_LOGIN": "用户名或密码无效",
-      "NOT_VERIFIED": "用户未验证"
-    },
-    "PASS_RESET": "没有用户或电子邮件与提供的数据匹配"
+      "NOT_VERIFIED": "用户未验证",
+      "PASS_RESET": "没有用户或电子邮件与提供的数据匹配"
+    }
   },
   "LANGUAGE": {
     "ES": "西班牙语",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -307,8 +307,10 @@
     "OAUTH": {
       "NO_CODE": "哎呀，你怎么会在这里？ 🤔"
     },
-    "INVALID_LOGIN": "用户名或密码无效",
-    "USER_NOT_VERIFIED": "用户未验证",
+    "USER": {
+      "INVALID_LOGIN": "用户名或密码无效",
+      "NOT_VERIFIED": "用户未验证"
+    },
     "PASS_RESET": "没有用户或电子邮件与提供的数据匹配"
   },
   "LANGUAGE": {

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -80,10 +80,6 @@
       "CONFIRM_PASSWORD": "确认密码",
       "CONFIRM_PASSWORD_PHOLDER": "确认您的密码"
     },
-    "ERROR": {
-      "INVALID_LOGIN": "用户名或密码无效",
-      "PASS_RESET": "没有用户或电子邮件与提供的数据匹配"
-    },
     "REGISTER": {
       "TERMS": "我同意<a href='/terms-conditions' class='terms-link' rel='noreferrer' target='_blank'>条款和条件</a>",
       "OPTION_TEXT": "- 或通过以下方式注册 -"
@@ -310,7 +306,10 @@
     },
     "OAUTH": {
       "NO_CODE": "哎呀，你怎么会在这里？ 🤔"
-    }
+    },
+    "INVALID_LOGIN": "用户名或密码无效",
+    "USER_NOT_VERIFIED": "用户未验证",
+    "PASS_RESET": "没有用户或电子邮件与提供的数据匹配"
   },
   "LANGUAGE": {
     "ES": "西班牙语",


### PR DESCRIPTION
Actualmente tanto el login como el forgot password detectan los errores con clave error. Para el forgot no hay problema, pero para el login hay discrepancia.

Dado que los errores del login son genericos y no afectan a ningun campo en especifico, se tendría que cambiar el backend para que devuelva la key error en lugar de non_fields_errors (el literal de este último debe ser ERROR.USER.INVALID_LOGIN)

Lo añadiré a la tare de @Atrujillo02 del refactor del registro, puesto que es una cosa muy pequeña para hacerle otra tarea